### PR TITLE
Oppdater test for behandlingresultat ENDRET

### DIFF
--- a/autotest/src/test/kotlin/no/nav/ba/e2e/autotest/ManuellBehandlingAvSøknadOgTekniskOpphørTest.kt
+++ b/autotest/src/test/kotlin/no/nav/ba/e2e/autotest/ManuellBehandlingAvSøknadOgTekniskOpphørTest.kt
@@ -204,7 +204,6 @@ class ManuellBehandlingAvSøknadOgTekniskOpphørTest(
                             restPersonResultat =
                             RestPersonResultat(personIdent = restPersonResultat.personIdent,
                                                vilkårResultater = listOf(it.copy(
-                                                       //resultat = Resultat.OPPFYLT,
                                                        periodeFom = LocalDate.parse(scenario.barna[1].fødselsdato)
                                                                .plusYears((eldsteBarnAlder / 2) + 1),
                                                        periodeTom = LocalDate.now()
@@ -293,14 +292,14 @@ class ManuellBehandlingAvSøknadOgTekniskOpphørTest(
 
         aktivBehandling.personResultater.forEach { restPersonResultat ->
             restPersonResultat.vilkårResultater?.forEach {
-                if (restPersonResultat.personIdent == scenario.barna[1].ident && it.vilkårType == Vilkår.BOR_MED_SØKER) {
+                if (restPersonResultat.personIdent == scenario.barna[1].ident || restPersonResultat.personIdent == scenario.søker.ident) {
                     familieBaSakKlient.putVilkår(
                             behandlingId = aktivBehandling.behandlingId,
                             vilkårId = it.id,
                             restPersonResultat =
                             RestPersonResultat(personIdent = restPersonResultat.personIdent,
                                                vilkårResultater = listOf(it.copy(
-                                                       resultat = Resultat.IKKE_OPPFYLT
+                                                       periodeTom = LocalDate.now().plusMonths(2)
                                                ))))
                 }
             }


### PR DESCRIPTION
Etter utbedring i utledning av behandlingresultat i ba-sak feiler e2e og vi får ENDRET_OG_OPPHØRT hvor test forventer ENDRET. Denne pr'en oppdaterer case til å gi ENDRET, slik som forventet. 

**Opprinnelig `Generering av vedtaksbrev for revurdering endret`-test**
Man baserer seg på foregående testdata hvor man setter vilkår til oppfylt denne måneden for å få opphørt.
Kjører etterpå og gjøres revurdering hvor man kun oppdaterer vilkårresultat til ikke_oppfylt. Så revurderingen gjør at vi får noe løpende vil resultat fortsatt inkludere opphørt. 

**Oppdatert `Generering av vedtaksbrev for revurdering endret`-test**
Kjører etterpå og gjøres revurdering hvor man utvider så det ene barnet blir løpende og vi kun får ENDRET