### PR TITLE
Spesifiser feil ved feilet ressurs

### DIFF
--- a/autotest/src/test/kotlin/no/nav/ba/e2e/commons/Utils.kt
+++ b/autotest/src/test/kotlin/no/nav/ba/e2e/commons/Utils.kt
@@ -6,6 +6,7 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import org.junit.jupiter.api.Assertions
 import no.nav.ba.e2e.familie_ba_sak.domene.RestVedtak
 import no.nav.ba.e2e.familie_ba_sak.domene.StegType
+import java.lang.IllegalStateException
 import java.time.LocalDate
 
 fun hentAktivBehandling(restFagsak: RestFagsak): RestBehandling? {
@@ -28,11 +29,10 @@ fun hentNåværendeEllerNesteMånedsUtbetaling(behandling: RestBehandling?): Int
 }
 
 fun generellAssertFagsak(restFagsak: Ressurs<RestFagsak>,
-                                 fagsakStatus: FagsakStatus,
-                                 behandlingStegType: StegType? = null,
-                                 behandlingResultat: BehandlingResultat? = null) {
-
-    Assertions.assertEquals(Ressurs.Status.SUKSESS, restFagsak.status)
+                         fagsakStatus: FagsakStatus,
+                         behandlingStegType: StegType? = null,
+                         behandlingResultat: BehandlingResultat? = null) {
+    if (restFagsak.status !== Ressurs.Status.SUKSESS) throw IllegalStateException("generellAssertFagsak feilet. status: ${restFagsak.status.name},  melding: ${restFagsak.melding}")
     Assertions.assertEquals(fagsakStatus, restFagsak.data?.status)
     if (behandlingStegType != null) {
         Assertions.assertEquals(behandlingStegType, hentAktivBehandling(restFagsak = restFagsak.data!!)?.steg)


### PR DESCRIPTION
Generell assert fagsak sjekker om ressurs er SUKSESS og dersom det feiler får man feedback "fikk FEILET ønsket SUKSESS": 
![Skjermbilde 2021-05-11 kl  17 15 39](https://user-images.githubusercontent.com/5719550/117843245-f1f63500-b27e-11eb-88d0-a7a4e9db2b3e.png)

Oppdaterer så denne sjekken heller kaster feil: 
![Skjermbilde 2021-05-11 kl  17 32 48](https://user-images.githubusercontent.com/5719550/117843258-f6225280-b27e-11eb-9e1b-72cd5fd0f105.png)

Kanskje man da klarer å forstå hva som feiler uten å dra opp e2e lokalt. 