### PR TITLE
Fjerner repo fram pom

### DIFF
--- a/autotest/pom.xml
+++ b/autotest/pom.xml
@@ -111,10 +111,6 @@
 
 	<repositories>
 		<repository>
-			<id>confluent</id>
-			<url>https://packages.confluent.io/maven/</url>
-		</repository>
-		<repository>
 			<id>github</id>
 			<url>https://maven.pkg.github.com/navikt/familie-felles</url>
 		</repository>


### PR DESCRIPTION
Tror vi klarer oss uten denne. Så unngår vi rare repomeldinger ved evt fremtidge endringer