### PR TITLE
La til håndtering for nytt steg vurder tilbakebetaling om steget finnes

### DIFF
--- a/autotest/pom.xml
+++ b/autotest/pom.xml
@@ -19,6 +19,7 @@
 		<kotlin.version>1.4.31</kotlin.version>
 		<confluent.version>5.3.1</confluent.version>
 		<felles.version>1.20210223111349_05be6ea</felles.version>
+		<felles-kontrakter.version>2.0_20210506101703_8c0e695</felles-kontrakter.version>
 		<token-validation-spring.version>1.3.3</token-validation-spring.version>
 	</properties>
 
@@ -51,6 +52,12 @@
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-swagger-ui</artifactId>
 			<version>2.9.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>no.nav.familie.kontrakter</groupId>
+			<artifactId>felles</artifactId>
+			<version>${felles-kontrakter.version}</version>
 		</dependency>
 
 		<dependency>

--- a/autotest/src/main/kotlin/no/nav/ba/e2e/familie_ba_sak/FamilieBaSakKlient.kt
+++ b/autotest/src/main/kotlin/no/nav/ba/e2e/familie_ba_sak/FamilieBaSakKlient.kt
@@ -90,6 +90,12 @@ class FamilieBaSakKlient(
         return postForEntity(uri, "")
     }
 
+    fun lagreTilbakekrevingOgGåVidereTilNesteSteg(behandlingId: Long,
+                                                  restTilbakekreving: RestTilbakekreving?): Ressurs<RestFagsak> {
+        val uri = URI.create("$baSakUrl/api/behandlinger/$behandlingId/tilbakekreving")
+        return postForEntity(uri, restTilbakekreving ?: "")
+    }
+
     fun sendTilBeslutter(fagsakId: Long): Ressurs<RestFagsak> {
         val uri = URI.create("$baSakUrl/api/fagsaker/$fagsakId/send-til-beslutter?behandlendeEnhet=9999")
 

--- a/autotest/src/main/kotlin/no/nav/ba/e2e/familie_ba_sak/FamilieBaSakKlient.kt
+++ b/autotest/src/main/kotlin/no/nav/ba/e2e/familie_ba_sak/FamilieBaSakKlient.kt
@@ -20,6 +20,7 @@ import no.nav.ba.e2e.familie_ba_sak.domene.RestPersonResultat
 import no.nav.ba.e2e.familie_ba_sak.domene.RestPostVedtakBegrunnelse
 import no.nav.ba.e2e.familie_ba_sak.domene.RestRegistrerSøknad
 import no.nav.ba.e2e.familie_ba_sak.domene.RestSøkParam
+import no.nav.ba.e2e.familie_ba_sak.domene.RestTilbakekreving
 import no.nav.familie.http.client.AbstractRestClient
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Ressurs

--- a/autotest/src/main/kotlin/no/nav/ba/e2e/familie_ba_sak/domene/RestTilbakekreving.kt
+++ b/autotest/src/main/kotlin/no/nav/ba/e2e/familie_ba_sak/domene/RestTilbakekreving.kt
@@ -1,0 +1,10 @@
+package no.nav.ba.e2e.familie_ba_sak.domene
+
+import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
+
+class RestTilbakekreving(
+        val valg: Tilbakekrevingsvalg,
+        val varsel: String? = null,
+        val begrunnelse: String,
+        val tilbakekrevingsbehandlingId: String? = null,
+)

--- a/autotest/src/test/kotlin/no/nav/ba/e2e/autotest/ManuellBehandlingAvJournalførtFørstegangssøknad.kt
+++ b/autotest/src/test/kotlin/no/nav/ba/e2e/autotest/ManuellBehandlingAvJournalførtFørstegangssøknad.kt
@@ -5,7 +5,6 @@ import no.nav.ba.e2e.commons.hentAktivBehandling
 import no.nav.ba.e2e.commons.hentNåværendeEllerNesteMånedsUtbetaling
 import no.nav.ba.e2e.commons.lagMockRestJournalføring
 import no.nav.ba.e2e.commons.lagSøknadDTO
-import no.nav.ba.e2e.commons.ordinærSats
 import no.nav.ba.e2e.commons.tilleggOrdinærSats
 import no.nav.ba.e2e.familie_ba_sak.FamilieBaSakKlient
 import no.nav.ba.e2e.familie_ba_sak.domene.Beslutning
@@ -25,6 +24,7 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.withPollInterval
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -110,13 +110,28 @@ class ManuellBehandlingAvJournalførtFørstegangssøknad(
                         behandlingId = aktivBehandlingEtterRegistrertSøknad.behandlingId
                 )
 
-        generellAssertFagsak(restFagsak = restFagsakEtterVilkårsvurdering,
+        //Midlertidig løsning for å håndtere med og uten simuleringssteg.
+        // TODO: Fjern når toggelen bruk_simulering er fjernet fra familie-ba-sak.
+        val behandlingEtterVilkårsvurdering = hentAktivBehandling(restFagsak = restFagsakEtterVilkårsvurdering.data!!)!!
+        var restFagsakEtterVurderTilbakekreving = restFagsakEtterVilkårsvurdering
+
+        if (behandlingEtterVilkårsvurdering.steg == StegType.VURDER_TILBAKEKREVING) {
+            generellAssertFagsak(restFagsak = restFagsakEtterVilkårsvurdering,
+                                 fagsakStatus = FagsakStatus.OPPRETTET,
+                                 behandlingStegType = StegType.VURDER_TILBAKEKREVING)
+
+            restFagsakEtterVurderTilbakekreving = familieBaSakKlient.lagreTilbakekrevingOgGåVidereTilNesteSteg(
+                    behandlingEtterVilkårsvurdering.behandlingId,
+                    null)
+        }
+
+        generellAssertFagsak(restFagsak = restFagsakEtterVurderTilbakekreving,
                              fagsakStatus = FagsakStatus.OPPRETTET,
                              behandlingStegType = StegType.SEND_TIL_BESLUTTER)
 
-        val vedtaksperiode = restFagsakEtterVilkårsvurdering.data!!.behandlinger.first().vedtaksperioder.first()
+        val vedtaksperiode = restFagsakEtterVurderTilbakekreving.data!!.behandlinger.first().vedtaksperioder.first()
         familieBaSakKlient.leggTilVedtakBegrunnelse(
-                fagsakId = restFagsakEtterVilkårsvurdering.data!!.id,
+                fagsakId = restFagsakEtterVurderTilbakekreving.data!!.id,
                 vedtakBegrunnelse = RestPostVedtakBegrunnelse(
                         fom = vedtaksperiode.periodeFom!!,
                         tom = vedtaksperiode.periodeTom,
@@ -125,17 +140,17 @@ class ManuellBehandlingAvJournalførtFørstegangssøknad(
 
         Assertions.assertEquals(tilleggOrdinærSats.beløp,
                                 hentNåværendeEllerNesteMånedsUtbetaling(
-                                        behandling = hentAktivBehandling(restFagsakEtterVilkårsvurdering.data!!)
+                                        behandling = hentAktivBehandling(restFagsakEtterVurderTilbakekreving.data!!)
                                 )
         )
 
         val restFagsakEtterSendTilBeslutter =
-                familieBaSakKlient.sendTilBeslutter(fagsakId = restFagsakEtterVilkårsvurdering.data!!.id)
+                familieBaSakKlient.sendTilBeslutter(fagsakId = restFagsakEtterVurderTilbakekreving.data!!.id)
         generellAssertFagsak(restFagsak = restFagsakEtterSendTilBeslutter,
                              fagsakStatus = FagsakStatus.OPPRETTET,
                              behandlingStegType = StegType.BESLUTTE_VEDTAK)
 
-        val restFagsakEtterIverksetting = familieBaSakKlient.iverksettVedtak(fagsakId = restFagsakEtterVilkårsvurdering.data!!.id,
+        val restFagsakEtterIverksetting = familieBaSakKlient.iverksettVedtak(fagsakId = restFagsakEtterVurderTilbakekreving.data!!.id,
                                                                              restBeslutningPåVedtak = RestBeslutningPåVedtak(
                                                                                      Beslutning.GODKJENT))
         generellAssertFagsak(restFagsak = restFagsakEtterIverksetting,

--- a/autotest/src/test/kotlin/no/nav/ba/e2e/autotest/ManuellBehandlingAvSøknadOgTekniskOpphørTest.kt
+++ b/autotest/src/test/kotlin/no/nav/ba/e2e/autotest/ManuellBehandlingAvSøknadOgTekniskOpphørTest.kt
@@ -125,14 +125,30 @@ class ManuellBehandlingAvSøknadOgTekniskOpphørTest(
                         behandlingId = aktivBehandlingEtterRegistrertSøknad.behandlingId
                 )
 
+        //Midlertidig løsning for å håndtere med og uten simuleringssteg.
+        // TODO: Fjern når toggelen bruk_simulering er fjernet fra familie-ba-sak.
+        val behandlingEtterVilkårsvurdering = hentAktivBehandling(restFagsak = restFagsakEtterVilkårsvurdering.data!!)!!
+        var restFagsakEtterVurderTilbakekreving = restFagsakEtterVilkårsvurdering
+
+        if (behandlingEtterVilkårsvurdering.steg == StegType.VURDER_TILBAKEKREVING) {
+            generellAssertFagsak(restFagsak = restFagsakEtterVilkårsvurdering,
+                                 fagsakStatus = FagsakStatus.OPPRETTET,
+                                 behandlingStegType = StegType.VURDER_TILBAKEKREVING,
+                                 behandlingResultat = BehandlingResultat.INNVILGET)
+
+            restFagsakEtterVurderTilbakekreving = familieBaSakKlient.lagreTilbakekrevingOgGåVidereTilNesteSteg(
+                    behandlingEtterVilkårsvurdering.behandlingId,
+                    null)
+        }
+
         generellAssertFagsak(restFagsak = restFagsakEtterVilkårsvurdering,
                              fagsakStatus = FagsakStatus.OPPRETTET,
                              behandlingStegType = StegType.SEND_TIL_BESLUTTER,
                              behandlingResultat = BehandlingResultat.INNVILGET)
 
-        val vedtaksperiode = restFagsakEtterVilkårsvurdering.data!!.behandlinger.first().vedtaksperioder.first()
+        val vedtaksperiode = restFagsakEtterVurderTilbakekreving.data!!.behandlinger.first().vedtaksperioder.first()
         val restFagsakEtterVedtaksbegrunnelser = familieBaSakKlient.leggTilVedtakBegrunnelse(
-                fagsakId = restFagsakEtterVilkårsvurdering.data!!.id,
+                fagsakId = restFagsakEtterVurderTilbakekreving.data!!.id,
                 vedtakBegrunnelse = RestPostVedtakBegrunnelse(
                         fom = vedtaksperiode.periodeFom!!,
                         tom = vedtaksperiode.periodeTom,
@@ -141,7 +157,7 @@ class ManuellBehandlingAvSøknadOgTekniskOpphørTest(
 
         assertEquals(ordinærSats.beløp + tilleggOrdinærSats.beløp,
                      hentNåværendeEllerNesteMånedsUtbetaling(
-                             behandling = hentAktivBehandling(restFagsakEtterVilkårsvurdering.data!!)
+                             behandling = hentAktivBehandling(restFagsakEtterVurderTilbakekreving.data!!)
                      )
         )
 
@@ -150,12 +166,12 @@ class ManuellBehandlingAvSøknadOgTekniskOpphørTest(
         Assertions.assertTrue(vedtaksbrevFørstegangsvedtak?.status == Ressurs.Status.SUKSESS)
 
         val restFagsakEtterSendTilBeslutter =
-                familieBaSakKlient.sendTilBeslutter(fagsakId = restFagsakEtterVilkårsvurdering.data!!.id)
+                familieBaSakKlient.sendTilBeslutter(fagsakId = restFagsakEtterVurderTilbakekreving.data!!.id)
         generellAssertFagsak(restFagsak = restFagsakEtterSendTilBeslutter,
                              fagsakStatus = FagsakStatus.OPPRETTET,
                              behandlingStegType = StegType.BESLUTTE_VEDTAK)
 
-        val restFagsakEtterIverksetting = familieBaSakKlient.iverksettVedtak(fagsakId = restFagsakEtterVilkårsvurdering.data!!.id,
+        val restFagsakEtterIverksetting = familieBaSakKlient.iverksettVedtak(fagsakId = restFagsakEtterVurderTilbakekreving.data!!.id,
                                                                              restBeslutningPåVedtak = RestBeslutningPåVedtak(
                                                                                      Beslutning.GODKJENT))
         generellAssertFagsak(restFagsak = restFagsakEtterIverksetting,
@@ -226,14 +242,31 @@ class ManuellBehandlingAvSøknadOgTekniskOpphørTest(
                 familieBaSakKlient.validerVilkårsvurdering(
                         behandlingId = aktivBehandling.behandlingId
                 )
-        generellAssertFagsak(restFagsak = restFagsakEtterVilkårsvurdering,
+
+        //Midlertidig løsning for å håndtere med og uten simuleringssteg.
+        // TODO: Fjern når toggelen bruk_simulering er fjernet fra familie-ba-sak.
+        val behandlingEtterVilkårsvurdering = hentAktivBehandling(restFagsak = restFagsakEtterVilkårsvurdering.data!!)!!
+        var restFagsakEtterVurderTilbakekreving = restFagsakEtterVilkårsvurdering
+
+        if (behandlingEtterVilkårsvurdering.steg == StegType.VURDER_TILBAKEKREVING) {
+            generellAssertFagsak(restFagsak = restFagsakEtterVilkårsvurdering,
+                                 fagsakStatus = FagsakStatus.OPPRETTET,
+                                 behandlingStegType = StegType.VURDER_TILBAKEKREVING,
+                                 behandlingResultat = BehandlingResultat.ENDRET_OG_OPPHØRT)
+
+            restFagsakEtterVurderTilbakekreving = familieBaSakKlient.lagreTilbakekrevingOgGåVidereTilNesteSteg(
+                    behandlingEtterVilkårsvurdering.behandlingId,
+                    null)
+        }
+
+        generellAssertFagsak(restFagsak = restFagsakEtterVurderTilbakekreving,
                              fagsakStatus = FagsakStatus.LØPENDE,
                              behandlingStegType = StegType.SEND_TIL_BESLUTTER,
                              behandlingResultat = BehandlingResultat.ENDRET_OG_OPPHØRT)
 
-        val vedtaksperiode = hentAktivBehandling(restFagsak = restFagsakEtterVilkårsvurdering.data!!)!!.vedtaksperioder.first()
+        val vedtaksperiode = hentAktivBehandling(restFagsak = restFagsakEtterVurderTilbakekreving.data!!)!!.vedtaksperioder.first()
         val restFagsakEtterVedtaksbegrunnelser = familieBaSakKlient.leggTilVedtakBegrunnelse(
-                fagsakId = restFagsakEtterVilkårsvurdering.data!!.id,
+                fagsakId = restFagsakEtterVurderTilbakekreving.data!!.id,
                 vedtakBegrunnelse = RestPostVedtakBegrunnelse(
                         fom = vedtaksperiode.periodeFom!!,
                         tom = vedtaksperiode.periodeTom,
@@ -246,12 +279,12 @@ class ManuellBehandlingAvSøknadOgTekniskOpphørTest(
         Assertions.assertTrue(vedtaksbrevRevurderingEndret?.data?.size ?: 0 > 0)
 
         val restFagsakEtterSendTilBeslutter =
-                familieBaSakKlient.sendTilBeslutter(fagsakId = restFagsakEtterVilkårsvurdering.data!!.id)
+                familieBaSakKlient.sendTilBeslutter(fagsakId = restFagsakEtterVurderTilbakekreving.data!!.id)
         generellAssertFagsak(restFagsak = restFagsakEtterSendTilBeslutter,
                              fagsakStatus = FagsakStatus.LØPENDE,
                              behandlingStegType = StegType.BESLUTTE_VEDTAK)
 
-        val restFagsakEtterIverksetting = familieBaSakKlient.iverksettVedtak(fagsakId = restFagsakEtterVilkårsvurdering.data!!.id,
+        val restFagsakEtterIverksetting = familieBaSakKlient.iverksettVedtak(fagsakId = restFagsakEtterVurderTilbakekreving.data!!.id,
                                                                              restBeslutningPåVedtak = RestBeslutningPåVedtak(
                                                                                      Beslutning.GODKJENT))
         generellAssertFagsak(restFagsak = restFagsakEtterIverksetting,
@@ -310,14 +343,32 @@ class ManuellBehandlingAvSøknadOgTekniskOpphørTest(
                 familieBaSakKlient.validerVilkårsvurdering(
                         behandlingId = aktivBehandling.behandlingId
                 )
-        generellAssertFagsak(restFagsak = restFagsakEtterVilkårsvurdering,
+
+        //Midlertidig løsning for å håndtere med og uten simuleringssteg.
+        // TODO: Fjern når toggelen bruk_simulering er fjernet fra familie-ba-sak.
+        val behandlingEtterVilkårsvurdering = hentAktivBehandling(restFagsak = restFagsakEtterVilkårsvurdering.data!!)!!
+        var restFagsakEtterVurderTilbakekreving = restFagsakEtterVilkårsvurdering
+
+        if (behandlingEtterVilkårsvurdering.steg == StegType.VURDER_TILBAKEKREVING) {
+            generellAssertFagsak(restFagsak = restFagsakEtterVilkårsvurdering,
+                                 fagsakStatus = FagsakStatus.OPPRETTET,
+                                 behandlingStegType = StegType.VURDER_TILBAKEKREVING,
+                                 behandlingResultat = BehandlingResultat.ENDRET)
+
+            restFagsakEtterVurderTilbakekreving = familieBaSakKlient.lagreTilbakekrevingOgGåVidereTilNesteSteg(
+                    behandlingEtterVilkårsvurdering.behandlingId,
+                    null)
+        }
+
+
+        generellAssertFagsak(restFagsak = restFagsakEtterVurderTilbakekreving,
                              fagsakStatus = FagsakStatus.LØPENDE,
                              behandlingStegType = StegType.SEND_TIL_BESLUTTER,
                              behandlingResultat = BehandlingResultat.ENDRET)
 
-        val vedtaksperiode = hentAktivBehandling(restFagsak = restFagsakEtterVilkårsvurdering.data!!)!!.vedtaksperioder.first()
+        val vedtaksperiode = hentAktivBehandling(restFagsak = restFagsakEtterVurderTilbakekreving.data!!)!!.vedtaksperioder.first()
         val restFagsakEtterVedtaksbegrunnelser = familieBaSakKlient.leggTilVedtakBegrunnelse(
-                fagsakId = restFagsakEtterVilkårsvurdering.data!!.id,
+                fagsakId = restFagsakEtterVurderTilbakekreving.data!!.id,
                 vedtakBegrunnelse = RestPostVedtakBegrunnelse(
                         fom = vedtaksperiode.periodeFom!!,
                         tom = vedtaksperiode.periodeTom,
@@ -372,18 +423,35 @@ class ManuellBehandlingAvSøknadOgTekniskOpphørTest(
                 familieBaSakKlient.validerVilkårsvurdering(
                         behandlingId = aktivBehandling.behandlingId
                 )
-        generellAssertFagsak(restFagsak = restFagsakEtterVilkårsvurdering,
+
+        //Midlertidig løsning for å håndtere med og uten simuleringssteg.
+        // TODO: Fjern når toggelen bruk_simulering er fjernet fra familie-ba-sak.
+        val behandlingEtterVilkårsvurdering = hentAktivBehandling(restFagsak = restFagsakEtterVilkårsvurdering.data!!)!!
+        var restFagsakEtterVurderTilbakekreving = restFagsakEtterVilkårsvurdering
+
+        if (behandlingEtterVilkårsvurdering.steg == StegType.VURDER_TILBAKEKREVING) {
+            generellAssertFagsak(restFagsak = restFagsakEtterVilkårsvurdering,
+                                 fagsakStatus = FagsakStatus.OPPRETTET,
+                                 behandlingStegType = StegType.VURDER_TILBAKEKREVING,
+                                 behandlingResultat = BehandlingResultat.OPPHØRT)
+
+            restFagsakEtterVurderTilbakekreving = familieBaSakKlient.lagreTilbakekrevingOgGåVidereTilNesteSteg(
+                    behandlingEtterVilkårsvurdering.behandlingId,
+                    null)
+        }
+
+        generellAssertFagsak(restFagsak = restFagsakEtterVurderTilbakekreving,
                              fagsakStatus = FagsakStatus.LØPENDE,
                              behandlingStegType = StegType.SEND_TIL_BESLUTTER,
                              behandlingResultat = BehandlingResultat.OPPHØRT)
 
         val restFagsakEtterSendTilBeslutter =
-                familieBaSakKlient.sendTilBeslutter(fagsakId = restFagsakEtterVilkårsvurdering.data!!.id)
+                familieBaSakKlient.sendTilBeslutter(fagsakId = restFagsakEtterVurderTilbakekreving.data!!.id)
         generellAssertFagsak(restFagsak = restFagsakEtterSendTilBeslutter,
                              fagsakStatus = FagsakStatus.LØPENDE,
                              behandlingStegType = StegType.BESLUTTE_VEDTAK)
 
-        val restFagsakEtterIverksetting = familieBaSakKlient.iverksettVedtak(fagsakId = restFagsakEtterVilkårsvurdering.data!!.id,
+        val restFagsakEtterIverksetting = familieBaSakKlient.iverksettVedtak(fagsakId = restFagsakEtterVurderTilbakekreving.data!!.id,
                                                                              restBeslutningPåVedtak = RestBeslutningPåVedtak(
                                                                                      Beslutning.GODKJENT))
         generellAssertFagsak(restFagsak = restFagsakEtterIverksetting,
@@ -446,14 +514,31 @@ class ManuellBehandlingAvSøknadOgTekniskOpphørTest(
                 familieBaSakKlient.validerVilkårsvurdering(
                         behandlingId = aktivBehandling.behandlingId
                 )
-        generellAssertFagsak(restFagsak = restFagsakEtterVilkårsvurdering,
+
+        //Midlertidig løsning for å håndtere med og uten simuleringssteg.
+        // TODO: Fjern når toggelen bruk_simulering er fjernet fra familie-ba-sak.
+        val behandlingEtterVilkårsvurdering = hentAktivBehandling(restFagsak = restFagsakEtterVilkårsvurdering.data!!)!!
+        var restFagsakEtterVurderTilbakekreving = restFagsakEtterVilkårsvurdering
+
+        if (behandlingEtterVilkårsvurdering.steg == StegType.VURDER_TILBAKEKREVING) {
+            generellAssertFagsak(restFagsak = restFagsakEtterVilkårsvurdering,
+                                 fagsakStatus = FagsakStatus.OPPRETTET,
+                                 behandlingStegType = StegType.VURDER_TILBAKEKREVING,
+                                 behandlingResultat = BehandlingResultat.OPPHØRT)
+
+            restFagsakEtterVurderTilbakekreving = familieBaSakKlient.lagreTilbakekrevingOgGåVidereTilNesteSteg(
+                    behandlingEtterVilkårsvurdering.behandlingId,
+                    null)
+        }
+
+        generellAssertFagsak(restFagsak = restFagsakEtterVurderTilbakekreving,
                              fagsakStatus = FagsakStatus.LØPENDE,
                              behandlingStegType = StegType.SEND_TIL_BESLUTTER,
                              behandlingResultat = BehandlingResultat.OPPHØRT)
 
-        val vedtaksperiode = hentAktivBehandling(restFagsak = restFagsakEtterVilkårsvurdering.data!!)!!.vedtaksperioder.first()
+        val vedtaksperiode = hentAktivBehandling(restFagsak = restFagsakEtterVurderTilbakekreving.data!!)!!.vedtaksperioder.first()
         val restFagsakEtterVedtaksbegrunnelser = familieBaSakKlient.leggTilVedtakBegrunnelse(
-                fagsakId = restFagsakEtterVilkårsvurdering.data!!.id,
+                fagsakId = restFagsakEtterVurderTilbakekreving.data!!.id,
                 vedtakBegrunnelse = RestPostVedtakBegrunnelse(
                         fom = vedtaksperiode.periodeFom!!,
                         tom = vedtaksperiode.periodeTom,
@@ -526,14 +611,30 @@ class ManuellBehandlingAvSøknadOgTekniskOpphørTest(
                         behandlingId = aktivBehandlingEtterRegistrertSøknad.behandlingId
                 )
 
-        generellAssertFagsak(restFagsak = restFagsakEtterVilkårsvurdering,
+        //Midlertidig løsning for å håndtere med og uten simuleringssteg.
+        // TODO: Fjern når toggelen bruk_simulering er fjernet fra familie-ba-sak.
+        val behandlingEtterVilkårsvurdering = hentAktivBehandling(restFagsak = restFagsakEtterVilkårsvurdering.data!!)!!
+        var restFagsakEtterVurderTilbakekreving = restFagsakEtterVilkårsvurdering
+
+        if (behandlingEtterVilkårsvurdering.steg == StegType.VURDER_TILBAKEKREVING) {
+            generellAssertFagsak(restFagsak = restFagsakEtterVilkårsvurdering,
+                                 fagsakStatus = FagsakStatus.OPPRETTET,
+                                 behandlingStegType = StegType.VURDER_TILBAKEKREVING,
+                                 behandlingResultat = BehandlingResultat.AVSLÅTT)
+
+            restFagsakEtterVurderTilbakekreving = familieBaSakKlient.lagreTilbakekrevingOgGåVidereTilNesteSteg(
+                    behandlingEtterVilkårsvurdering.behandlingId,
+                    null)
+        }
+
+        generellAssertFagsak(restFagsak = restFagsakEtterVurderTilbakekreving,
                              fagsakStatus = FagsakStatus.OPPRETTET,
                              behandlingStegType = StegType.SEND_TIL_BESLUTTER,
                              behandlingResultat = BehandlingResultat.AVSLÅTT)
 
 
         val vedtaksbrevOpphørt = familieBaSakKlient.genererOgHentVedtaksbrev(
-                hentAktivtVedtak(restFagsak = restFagsakEtterVilkårsvurdering.data!!)!!.id)
+                hentAktivtVedtak(restFagsak = restFagsakEtterVurderTilbakekreving.data!!)!!.id)
         Assertions.assertTrue(vedtaksbrevOpphørt?.status == Ressurs.Status.SUKSESS)
         Assertions.assertTrue(vedtaksbrevOpphørt?.data?.size ?: 0 > 0)
     }


### PR DESCRIPTION
La til håndtering for nytt steg vurder tilbakebetaling om steget finnes.

Et nytt steg 'vurder tilbakemelding' har blitt lagt til i ba-sak mellom stegen vilkårsvurdering og 'send til beslutter'.
Testene har blitt endret sånn at både ny og gammel stegsekvens blir håndtert.