### PR TITLE
Skrur litt på surefire config'en

### DIFF
--- a/autotest/pom.xml
+++ b/autotest/pom.xml
@@ -164,9 +164,8 @@
 				<configuration>
 					<threadCount>2</threadCount>
 					<rerunFailingTestsCount>3</rerunFailingTestsCount>
-					<threadCountClasses>4</threadCountClasses>
 					<parallel>suitesAndClasses</parallel>
-					<forkCount>1C</forkCount>
+					<forkCount>3</forkCount>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/autotest/pom.xml
+++ b/autotest/pom.xml
@@ -164,7 +164,7 @@
 				<configuration>
 					<threadCount>2</threadCount>
 					<rerunFailingTestsCount>3</rerunFailingTestsCount>
-					<parallel>suitesAndClasses</parallel>
+					<parallel>all</parallel>
 					<forkCount>3</forkCount>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
Begrenser forkCount til 3 (reduserte kjøretiden med ca. et minutt lokalt).
Fjerner threadCountClasses, da den ikke har noe å si for forkCount > 1 (klassene kjøres i hver sin "fork" istedet)