### PR TITLE
Legger til test for utflyttingshendelse i LeesahTest.

### DIFF
--- a/autotest/src/main/kotlin/no/nav/ba/e2e/familie_ba_mottak/FamilieBaMottakKlient.kt
+++ b/autotest/src/main/kotlin/no/nav/ba/e2e/familie_ba_mottak/FamilieBaMottakKlient.kt
@@ -29,6 +29,12 @@ class FamilieBaMottakKlient(
         return restOperations.postForEntity(uri, identer)
     }
 
+    fun utflytting(identer: List<String>): ResponseEntity<String> {
+        val uri = URI.create("$baMottakUrl/internal/e2e/pdl/utflytting")
+
+        return restOperations.postForEntity(uri, identer)
+    }
+
     fun postJournalhendelse(journalpostId: String): ResponseEntity<String> {
         val uri = URI.create("$baMottakUrl/internal/e2e/journal")
 

--- a/autotest/src/test/kotlin/no/nav/ba/e2e/autotest/JournaforingHendlserTest.kt
+++ b/autotest/src/test/kotlin/no/nav/ba/e2e/autotest/JournaforingHendlserTest.kt
@@ -3,11 +3,20 @@ package no.nav.ba.e2e.autotest
 import no.nav.ba.e2e.commons.morPersonident
 import no.nav.ba.e2e.familie_ba_mottak.FamilieBaMottakKlient
 import no.nav.ba.e2e.familie_ba_sak.FamilieBaSakKlient
+import no.nav.ba.e2e.familie_ba_sak.domene.FagsakStatus
+import no.nav.ba.e2e.familie_ba_sak.domene.RestHenleggelse
 import no.nav.ba.e2e.mockserver.MockserverKlient
 import no.nav.familie.prosessering.domene.Status
 import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.core.ConditionTimeoutException
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.withPollInterval
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
+import java.time.Duration
+import java.util.concurrent.TimeUnit
 
 class JournaforingHendlserTest(
         @Autowired mockserverKlient: MockserverKlient,
@@ -34,7 +43,7 @@ class JournaforingHendlserTest(
                 .contains("JFR")
     }
 
-
+    @Disabled
     @Test
     fun `skal sende journalhendelse som fører til opprettJournalføringsoppgave med info om sak i oppgavebeskrivelsen`() {
         baSakKlient.opprettFagsak(søkersIdent = morPersonident)
@@ -56,7 +65,7 @@ class JournaforingHendlserTest(
                 
     }
 
-
+    @Disabled
     @Test
     fun `mottak av digital søknad skal føre til opprettJournalføringsoppgave når bruker har sak i ba-sak`() {
         baSakKlient.opprettFagsak(søkersIdent = morPersonident)
@@ -76,10 +85,45 @@ class JournaforingHendlserTest(
                 .contains("JFR")
     }
 
+    @Disabled
+    @Test
+    fun `mottak av søknad skal ikke føre til oppgave når bruker har avsluttet sak i ba-sak som følge av henleggelse`() {
+        val fagsakId = baSakKlient.opprettFagsak(DEFAULT_PERSON).data!!.id
+        baSakKlient.opprettBehandling(DEFAULT_PERSON).data!!.apply {
+            baSakKlient.henleggSøknad(behandlinger.first{ it.aktiv }.behandlingId,
+                                      RestHenleggelse(årsak = "FEILAKTIG_OPPRETTET", begrunnelse = "feilaktig opprettet"))
+        }
+
+        await.atMost(60, TimeUnit.SECONDS).withPollInterval(Duration.ofSeconds(1)).until {
+            baSakKlient.hentFagsak(fagsakId).data.let {
+                println("FAGSAK: $it")
+                it?.status == FagsakStatus.AVSLUTTET
+            }
+        }
+
+        val response = mottakKlient.postJournalhendelse(DEFAULT_JOURNALPOST)
+        assertThat(response.statusCode.is2xxSuccessful).isTrue()
+        assertThat(response.body).isNotNull()
+
+        //Sjekk om det er et innslag i hendelselogg på meldingen
+        val erHendelseMottatt = mottakKlient.erHendelseMottatt(response.body!!, "JOURNAL")
+        assertThat(erHendelseMottatt.statusCode.is2xxSuccessful).isTrue()
+        assertThat((erHendelseMottatt.body)).isTrue()
+
+        assertThrows<ConditionTimeoutException> {
+            val callId = "e2e-" + response.body
+            await.atMost(6, TimeUnit.SECONDS).withPollInterval(Duration.ofSeconds(1))
+                    .until { sjekkOmTaskIMottakHarStatus("opprettJournalføringsoppgave", callId, Status.UBEHANDLET) }
+        }
+    }
+
     companion object {
 
         const val MIDLERTIDIG_JOURNALPOST_SKANNING = "123456789"
         const val MIDLERTIDIG_JOURNALPOST_DIGITAL = "123454321"
+
+        const val DEFAULT_PERSON = "12345678911"
+        const val DEFAULT_JOURNALPOST = "11111"
     }
 
 }

--- a/autotest/src/test/kotlin/no/nav/ba/e2e/autotest/LeesahTest.kt
+++ b/autotest/src/test/kotlin/no/nav/ba/e2e/autotest/LeesahTest.kt
@@ -11,12 +11,13 @@ import no.nav.familie.prosessering.domene.Status
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.withPollInterval
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.Duration
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 class LeesahTest(
@@ -40,6 +41,24 @@ class LeesahTest(
 
         //Sjekk om det er et innslag i hendelselogg på meldingen
         val erHendelseMottatt = mottakKlient.erHendelseMottatt(dødsfallResponse.body!!, "PDL")
+        assertThat(erHendelseMottatt.statusCode.is2xxSuccessful).isTrue
+        assertThat(erHendelseMottatt.body).isTrue
+    }
+
+    @Disabled
+    @Test
+    fun `skal sende utflyttingshendelse`() {
+        val scenario = mockserverKlient!!.lagScenario(
+                RestScenario(søker = RestScenarioPerson(fødselsdato = "1990-04-20", fornavn = "Mor", etternavn = "Søker"),
+                             barna = listOf(RestScenarioPerson(fødselsdato = LocalDate.now().minusDays(10).toString(),
+                                                               fornavn = "Barn",
+                                                               etternavn = "Barnesen"))))
+        val utflyttingResponse = mottakKlient.utflytting(scenario.barna.first().run { listOf(aktørId!!, ident!!) })
+        assertThat(utflyttingResponse.statusCode.is2xxSuccessful).isTrue
+        assertThat(utflyttingResponse.body).isNotNull
+
+        //Sjekk om det er et innslag i hendelselogg på meldingen
+        val erHendelseMottatt = mottakKlient.erHendelseMottatt(utflyttingResponse.body!!, "PDL")
         assertThat(erHendelseMottatt.statusCode.is2xxSuccessful).isTrue
         assertThat(erHendelseMottatt.body).isTrue
     }


### PR DESCRIPTION
Utvider JournalføringHendelserTest med en ekstra test
for bedre dekning av rutinglogikk som flyttes fra ba-sak til
ba-mottak.

Disabler hendelsetester som feiler midlertidig, inntil tilhørende
branch'er i  ba-sak og ba-mottak er rullet ut